### PR TITLE
Fix/main navigation on mobile in horizontal mode

### DIFF
--- a/components/molecules/MainNav.tsx
+++ b/components/molecules/MainNav.tsx
@@ -55,7 +55,7 @@ export const MainNav = memo(() => {
       role="navigation"
       className={`${
         uiState.isMenuOpen ? 'translate-x-0' : 'translate-x-full'
-      } left-0 top-0 z-40 lg:transform-none lg:flex lg:bg-transparent lg:static lg:w-auto lg:h-auto fixed w-full h-screen transition-transform bg-gray-100 flex lg:flex-1 lg:items-stretch`}
+      } left-0 top-0 z-40 lg:transform-none lg:flex lg:bg-transparent lg:static lg:w-auto lg:h-auto fixed w-full min-h-full transition-transform bg-gray-100 flex lg:flex-1 items-center lg:items-stretch`}
     >
       <div className="overflow-scrolling-touch pb-24 pt-16 w-full h-full max-h-screen overflow-y-scroll overscroll-y-none lg:pb-0 lg:pt-0 lg:overflow-y-auto">
         <ul className="flex flex-1 flex-col gap-8 items-center justify-center h-full text-3xl lg:flex-row lg:gap-0 lg:items-stretch lg:justify-around lg:text-base">

--- a/components/molecules/MainNav.tsx
+++ b/components/molecules/MainNav.tsx
@@ -37,7 +37,7 @@ const navItems: readonly { readonly slug: string; readonly label: ReactNode; rea
   {
     slug: 'wspolpraca',
     label: 'O mnie i współpraca',
-    className: 'md:hidden',
+    className: 'lg:hidden',
   },
 ];
 

--- a/components/molecules/MainNav.tsx
+++ b/components/molecules/MainNav.tsx
@@ -55,10 +55,10 @@ export const MainNav = memo(() => {
       role="navigation"
       className={`${
         uiState.isMenuOpen ? 'translate-x-0' : 'translate-x-full'
-      } left-0 top-0 z-40 lg:transform-none lg:flex lg:bg-transparent lg:static lg:w-auto lg:h-auto fixed w-full min-h-full transition-transform bg-gray-100 flex lg:flex-1 items-center lg:items-stretch`}
+      } left-0 top-0 bottom-0 z-40 lg:transform-none lg:flex lg:bg-transparent lg:static lg:w-auto lg:h-auto fixed w-full min-h-full transition-transform bg-gray-100 flex lg:flex-1 items-center lg:items-stretch`}
     >
-      <div className="overflow-scrolling-touch pb-24 pt-16 w-full h-full max-h-screen overflow-y-scroll overscroll-y-none lg:pb-0 lg:pt-0 lg:overflow-y-auto">
-        <ul className="flex flex-1 flex-col gap-8 items-center justify-center h-full text-3xl lg:flex-row lg:gap-0 lg:items-stretch lg:justify-around lg:text-base">
+      <div className="overflow-y-auto w-full h-full max-h-screen overflow-y-scroll overscroll-y-none lg:pb-0 lg:pt-0 lg:overflow-y-auto">
+        <ul className="flex lg:flex-1 flex-col gap-8 items-center justify-center lg:h-full text-3xl lg:flex-row lg:gap-0 lg:items-stretch lg:justify-around lg:text-base pt-16 pb-24 lg:py-0">
           {navItems.map((item) => {
             const isActive = permalink === item.slug;
             return (

--- a/components/molecules/MainNav.tsx
+++ b/components/molecules/MainNav.tsx
@@ -57,7 +57,7 @@ export const MainNav = memo(() => {
         uiState.isMenuOpen ? 'translate-x-0' : 'translate-x-full'
       } left-0 top-0 bottom-0 z-40 lg:transform-none lg:flex lg:bg-transparent lg:static lg:w-auto lg:h-auto fixed w-full min-h-full transition-transform bg-gray-100 flex lg:flex-1 items-center lg:items-stretch`}
     >
-      <div className="overflow-y-auto w-full h-full max-h-screen overflow-y-scroll overscroll-y-none lg:pb-0 lg:pt-0 lg:overflow-y-auto">
+      <div className="overflow-y-auto w-full h-full max-h-screen lg:pb-0 lg:pt-0">
         <ul className="flex lg:flex-1 flex-col gap-8 items-center justify-center lg:h-full text-3xl lg:flex-row lg:gap-0 lg:items-stretch lg:justify-around lg:text-base pt-16 pb-24 lg:py-0">
           {navItems.map((item) => {
             const isActive = permalink === item.slug;


### PR DESCRIPTION
### Before:

There are certain menu items that we cannot access:
![before](https://user-images.githubusercontent.com/27455716/206863541-8cd82873-0211-45b0-b618-5ce56f08ac9b.JPG)

### After:

Full access to all of the main menu items in horizontal mode:
![after](https://user-images.githubusercontent.com/27455716/206863634-2cc1b901-8de9-4cc0-a582-2be03df82057.JPG)

Additionally unhide "O mnie i współpraca" menu item in case when user viewport width is ≤1024px (lg) as it was when user viewport has ≤768px (md) before this change.