### PR TITLE
fix: adjust VideoSneakPeak thunmbnail size

### DIFF
--- a/components/organisms/VideoSneakPeek.tsx
+++ b/components/organisms/VideoSneakPeek.tsx
@@ -31,7 +31,7 @@ export const VideoSneakPeek = memo<VideoSneakPeekProps>(({ video }) => {
             </a>
           </div>
           {video.cover && (
-            <div className="order-1 w-full max-w-[9rem] min-w-[4rem] ml-6 mr-10 -mt-2 lg:-mt-6 relative">
+            <div className="order-1 w-full ml-6 mr-10 -mt-2 lg:-mt-6 relative basis-16 sm:basis-36 shrink-0">
               <a href={video.url} target="_blank" tabIndex={-1} aria-hidden="true" className="block" rel="noreferrer">
                 <ArticleCoverImage
                   cover={{


### PR DESCRIPTION
PR naprawia problem z rozmiarem miniaturki wideo w komponencie `VideoSneakPeak` - mianowicie obecnie jest ona różna w zależności od długości tytułu obok. Naprawa polega na ustaleniu określonej szerokości elementu, w którym miniaturka się znajduje.

Problem:

![typeofweb](https://user-images.githubusercontent.com/27455716/210402613-4eb79def-6864-4a84-b1e5-53978de3d062.png)
